### PR TITLE
Bug filename space

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -161,7 +161,8 @@ Feature: CSVlint CLI
 NO JSON HERE SON
     """
     And the schema is stored at the url "http://example.com/schema.json"
-    Then nothing should be outputted to STDERR
+    # This case is commented since error logging is now enabled to understand the error situation better
+    # Then nothing should be outputted to STDERR 
     When I run `csvlint http://example.com/example1.csv --schema http://example.com/schema.json`
     And the output should contain "invalid metadata: malformed JSON"
 

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -54,7 +54,7 @@ module Csvlint
 
     def get_schema(schema)
       begin
-        schema = Csvlint::Schema.load_from_uri(schema, false)
+        schema = Csvlint::Schema.load_from_uri(schema, true)
       rescue Csvlint::Csvw::MetadataError => e
         return_error "invalid metadata: #{e.message}#{' at ' + e.path if e.path}"
       rescue OpenURI::HTTPError, Errno::ENOENT

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -59,7 +59,7 @@ module Csvlint
         annotations = {}
         inherited_properties = {}
         common_properties = {}
-        base_url = URI(url.to_s.strip)
+        base_url = URI(URI.encode(url.to_s.strip))
         lang = "und"
 
         context = json["@context"]

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -59,6 +59,7 @@ module Csvlint
         annotations = {}
         inherited_properties = {}
         common_properties = {}
+        STDERR.puts "Warning: The path/url has whitespaces in it, please ensure its correctness. Proceeding with received path/url .." if url.to_s.strip =~ /\s/
         base_url = URI(URI.encode(url.to_s.strip))
         lang = "und"
 

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -45,6 +45,7 @@ module Csvlint
 
       def load_from_string(uri, string, output_errors = true)
         begin
+          uri = uri.gsub(/\s/, "\\ ")
           json = JSON.parse( string )
           if json["@context"]
             uri = "file:#{File.expand_path(uri)}" unless uri.to_s =~ /^http(s)?/

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -45,7 +45,6 @@ module Csvlint
 
       def load_from_string(uri, string, output_errors = true)
         begin
-          uri = uri.gsub(/\s/, "\\ ")
           json = JSON.parse( string )
           if json["@context"]
             uri = "file:#{File.expand_path(uri)}" unless uri.to_s =~ /^http(s)?/


### PR DESCRIPTION
This PR fixes the bug when schema json file supplied have spaces in its path/filename. 

Changes proposed in this pull request:

- Accept JSON schema filenames with spaces
- Set output_errors flag to view any errors during execution
