### PR TITLE
Remove consistency check if schema provided

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,5 @@
 pipeline {
-    agent {
-        label 'master'
-    }
+    agent none
     stages {
         stage('Test') {
             agent {
@@ -11,6 +9,10 @@ pipeline {
             }
             steps {
                 sh "bundle install"
+                sh "rm bin/run-csvw-tests"
+                sh "rm features/csvw_validation_tests.feature"
+                sh "rm -r features/fixtures/csvw"
+                sh "ruby features/support/load_tests.rb"
                 sh "rake"
                 sh "bundle exec cucumber -f junit -o test-results"
             }
@@ -19,7 +21,9 @@ pipeline {
     post {
         always {
             script {
-                junit allowEmptyResults: true, testResults: 'test-results/*.xml'
+                node {
+                    junit allowEmptyResults: true, testResults: 'test-results/*.xml'
+                }
             }
         }
     }

--- a/features/check_format.feature
+++ b/features/check_format.feature
@@ -9,7 +9,7 @@ Feature: Check inconsistent formatting
 "3","2","1"
     """
     And it is stored at the url "http://example.com/example1.csv"
-    And I ask if there are warnings
+    And I ask if there are warnings without providing schema
     Then there should be 1 warnings
     And that warning should have the type "inconsistent_values"
     And that warning should have the column "1"
@@ -23,7 +23,7 @@ Feature: Check inconsistent formatting
 "Boff","Giff","Goff"
     """
     And it is stored at the url "http://example.com/example1.csv"
-    And I ask if there are warnings
+    And I ask if there are warnings without providing schema
     Then there should be 1 warnings
     And that warning should have the type "inconsistent_values"
     And that warning should have the column "2"
@@ -37,7 +37,7 @@ Feature: Check inconsistent formatting
 "Boff444","Giff","Goff"
     """
     And it is stored at the url "http://example.com/example1.csv"
-    And I ask if there are warnings
+    And I ask if there are warnings without providing schema
     Then there should be 1 warnings
     And that warning should have the type "inconsistent_values"
     And that warning should have the column "1"

--- a/features/step_definitions/validation_warnings_steps.rb
+++ b/features/step_definitions/validation_warnings_steps.rb
@@ -29,6 +29,12 @@ When(/^I ask if there are warnings$/) do
   @warnings = @validator.warnings
 end
 
+When(/^I ask if there are warnings without providing schema$/) do
+  @csv_options ||= default_csv_options
+  @validator = Csvlint::Validator.new( @url, @csv_options)
+  @warnings = @validator.warnings
+end
+
 Then(/^there should be warnings$/) do
   expect( @warnings.count ).to be > 0
 end

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -216,7 +216,7 @@ module Csvlint
       end
       # return expected_columns to calling class
       build_warnings(:check_options, :structure) if @expected_columns == 1
-      check_consistency
+      check_consistency unless @schema
       check_foreign_keys if @validate
       check_mixed_linebreaks
       validate_encoding


### PR DESCRIPTION
This PR fixes #

Changes proposed in this pull request:

- When a schema is provided, skip consistency checks as doing so will mark some csv files as invalid even though it is not. 
