### PR TITLE
Performance improvement - remove collecting every row in a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ best practices
 	validator.encoding
 	validator.content_type
 	validator.extension
+	validator.row_count
 
 	#retrieve HTTP headers from request
 	validator.headers

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ best practices
 	validator.encoding
 	validator.content_type
 	validator.extension
-	validator.row_count
 
 	#retrieve HTTP headers from request
 	validator.headers

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -50,7 +50,7 @@ module Csvlint
 
     include Csvlint::ErrorCollector
 
-    attr_reader :encoding, :content_type, :extension, :headers, :link_headers, :dialect, :csv_header, :schema, :data, :current_line
+    attr_reader :encoding, :content_type, :extension, :headers, :link_headers, :dialect, :csv_header, :schema, :row_count, :current_line
 
     ERROR_MATCHERS = {
         "Missing or stray quote" => :stray_quote,
@@ -80,6 +80,8 @@ module Csvlint
 
       @errors += @schema.errors unless @schema.nil?
       @warnings += @schema.warnings unless @schema.nil?
+
+      @row_count = 0
       validate
     end
 
@@ -203,6 +205,7 @@ module Csvlint
           end
         end
       end
+      @row_count += 1
     end
 
     def finish

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -80,9 +80,6 @@ module Csvlint
 
       @errors += @schema.errors unless @schema.nil?
       @warnings += @schema.warnings unless @schema.nil?
-
-      @data = [] # it may be advisable to flush this on init?
-
       validate
     end
 
@@ -206,7 +203,6 @@ module Csvlint
           end
         end
       end
-      @data << row
     end
 
     def finish
@@ -329,10 +325,6 @@ module Csvlint
       else
         @line_breaks.uniq.first
       end
-    end
-
-    def row_count
-      data.count
     end
 
     def build_exception_messages(csvException, errChars, lineNo)

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -16,7 +16,6 @@ describe Csvlint::Validator do
     expect(validator.valid?).to eql(true)
     expect(validator.instance_variable_get("@expected_columns")).to eql(3)
     expect(validator.instance_variable_get("@col_counts").count).to eql(3)
-    expect(validator.data.size).to eql(3)
   end
 
   it "should validate from a file path" do
@@ -25,7 +24,6 @@ describe Csvlint::Validator do
     expect(validator.valid?).to eql(true)
     expect(validator.instance_variable_get("@expected_columns")).to eql(3)
     expect(validator.instance_variable_get("@col_counts").count).to eql(3)
-    expect(validator.data.size).to eql(3)
   end
 
   it "should validate from a file path including whitespace" do
@@ -61,7 +59,6 @@ describe Csvlint::Validator do
       # TODO in its formats object but is provided with 5 rows (with one nil row) [uses validation_warnings_steps.rb]
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
-      expect(validator.data.size).to eql(4)
 
     end
 
@@ -149,7 +146,6 @@ describe Csvlint::Validator do
       expect(validator.valid?).to eql(true)
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
-      expect(validator.data.size).to eql(4)
       expect(validator.info_messages.count).to eql(1)
     end
 
@@ -161,7 +157,6 @@ describe Csvlint::Validator do
       expect(validator.valid?).to eql(false)
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
-      expect(validator.data.size).to eql(5)
       expect(validator.info_messages.count).to eql(1)
       expect(validator.errors.count).to eql(1)
       expect(validator.errors.first.type).to eql(:whitespace)
@@ -577,19 +572,6 @@ describe Csvlint::Validator do
         :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
     validator = Csvlint::Validator.new("http://example.com/example.csv")
     expect( validator.valid? ).to eql(true)
-    data = validator.data
-
-    expect( data.count ).to eql 3
-    expect( data[0] ).to eql ['Foo','Bar','Baz']
-    expect( data[2] ).to eql ['3','2','1']
-  end
-
-  it "should count the total number of rows read" do
-    stub_request(:get, "http://example.com/example.csv").to_return(:status => 200,
-        :headers=>{"Content-Type" => "text/csv; header=present"},
-        :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
-    validator = Csvlint::Validator.new("http://example.com/example.csv")
-    expect(validator.row_count).to eq(3)
   end
 
   it "should limit number of lines read" do
@@ -598,9 +580,6 @@ describe Csvlint::Validator do
     :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
     validator = Csvlint::Validator.new("http://example.com/example.csv", {}, nil, limit_lines: 2)
     expect( validator.valid? ).to eql(true)
-    data = validator.data
-    expect( data.count ).to eql 2
-    expect( data[0] ).to eql ['Foo','Bar','Baz']
   end
 
   context "with a lambda" do

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -16,6 +16,7 @@ describe Csvlint::Validator do
     expect(validator.valid?).to eql(true)
     expect(validator.instance_variable_get("@expected_columns")).to eql(3)
     expect(validator.instance_variable_get("@col_counts").count).to eql(3)
+    expect(validator.row_count).to eql(3)
   end
 
   it "should validate from a file path" do
@@ -24,6 +25,7 @@ describe Csvlint::Validator do
     expect(validator.valid?).to eql(true)
     expect(validator.instance_variable_get("@expected_columns")).to eql(3)
     expect(validator.instance_variable_get("@col_counts").count).to eql(3)
+    expect(validator.row_count).to eql(3)
   end
 
   it "should validate from a file path including whitespace" do
@@ -45,7 +47,7 @@ describe Csvlint::Validator do
     # TODO multiple lines permits testing of warnings
     # TODO need more assertions in each test IE @formats
     # TODO the phrasing of col_counts if only consulting specs might be confusing
-    # TODO ^-> col_counts and data.size should be equivalent, but only data is populated outside of if row.nil?
+    # TODO ^-> col_counts and row_count should be equivalent, but only data is populated outside of if row.nil?
     # TODO ^- -> and its less the size of col_counts than the homogeneity of its contents which is important
 
     it ".each() -> parse_contents method validates a well formed CSV" do
@@ -59,6 +61,7 @@ describe Csvlint::Validator do
       # TODO in its formats object but is provided with 5 rows (with one nil row) [uses validation_warnings_steps.rb]
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
+      expect(validator.row_count).to eql(4)
 
     end
 
@@ -146,6 +149,7 @@ describe Csvlint::Validator do
       expect(validator.valid?).to eql(true)
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
+      expect(validator.row_count).to eql(4)
       expect(validator.info_messages.count).to eql(1)
     end
 
@@ -157,6 +161,7 @@ describe Csvlint::Validator do
       expect(validator.valid?).to eql(false)
       expect(validator.instance_variable_get("@expected_columns")).to eql(3)
       expect(validator.instance_variable_get("@col_counts").count).to eql(4)
+      expect(validator.row_count).to eql(5)
       expect(validator.info_messages.count).to eql(1)
       expect(validator.errors.count).to eql(1)
       expect(validator.errors.first.type).to eql(:whitespace)
@@ -572,6 +577,15 @@ describe Csvlint::Validator do
         :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
     validator = Csvlint::Validator.new("http://example.com/example.csv")
     expect( validator.valid? ).to eql(true)
+    expect( validator.row_count ).to eql 3
+  end
+
+  it "should count the total number of rows read" do
+    stub_request(:get, "http://example.com/example.csv").to_return(:status => 200,
+        :headers=>{"Content-Type" => "text/csv; header=present"},
+        :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
+    validator = Csvlint::Validator.new("http://example.com/example.csv")
+    expect(validator.row_count).to eq(3)
   end
 
   it "should limit number of lines read" do
@@ -580,6 +594,7 @@ describe Csvlint::Validator do
     :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
     validator = Csvlint::Validator.new("http://example.com/example.csv", {}, nil, limit_lines: 2)
     expect( validator.valid? ).to eql(true)
+    expect( validator.row_count ).to eql 2
   end
 
   context "with a lambda" do


### PR DESCRIPTION
Removing collection of rows in a variable will break some Unit tests but it is not part of the w3c spec in my opinion. So I have removed these assertions which no longer works.

Also a method named row_count which returns the total number of rows in the csv file is also removed.