### PR TITLE
Output some JUnit style XML

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -78,7 +78,7 @@ Feature: CSVlint CLI
     "Foo",	"Bar"	,	"Baz"
     """
     And it is stored at the url "http://example.com/example1.csv"
-    When I run `csvlint http://example.com/example1.csv --json`
+    When I run `csvlint http://example.com/example1.csv --format json`
     Then the output should contain JSON
     And the JSON should have a state of "invalid"
     And the JSON should have 1 error
@@ -148,7 +148,7 @@ Feature: CSVlint CLI
 }
     """
     And the schema is stored at the url "http://example.com/schema.json"
-    When I run `csvlint http://example.com/example1.csv --schema http://example.com/schema.json --json`
+    When I run `csvlint http://example.com/example1.csv --schema http://example.com/schema.json --format json`
     Then the output should contain JSON
     And the JSON should have a state of "invalid"
     And the JSON should have 1 error
@@ -257,3 +257,24 @@ NO JSON HERE SON
     When I run `csvlint --schema http://w3c.github.io/csvw/tests/countries.json`
     Then the output should contain "http://w3c.github.io/csvw/tests/countries.csv is VALID"
     And the output should contain "http://w3c.github.io/csvw/tests/country_slice.csv is VALID"
+
+  Scenario: Schema errors with JUnit
+    Given I have a CSV with the following content:
+    """
+"Bob","1234","bob@example.org"
+"Alice","5","alice@example.com"
+    """
+    And it is stored at the url "http://example.com/example1.csv"
+    And I have a schema with the following content:
+    """
+{
+  "fields": [
+          { "name": "Name", "constraints": { "required": true } },
+          { "name": "Id", "constraints": { "required": true, "minLength": 3 } },
+          { "name": "Email", "constraints": { "required": true } }
+    ]
+}
+    """
+    And the schema is stored at the url "http://example.com/schema.json"
+    When I run `csvlint http://example.com/example1.csv --schema http://example.com/schema.json --format junit`
+    Then the output should be XML

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -1,3 +1,6 @@
+require "active_support"
+require "active_support/core_ext/hash"
+
 Given(/^I have stubbed stdin to contain "(.*?)"$/) do |file|
   expect(STDIN).to receive(:read).and_return(File.read(file))
 end
@@ -34,4 +37,8 @@ end
 
 Then(/^error (\d+) should have the constraint "(.*?)" "(.*?)"$/) do |index, k, v|
   expect(@json['validation']['errors'][index.to_i - 1]['constraints'][k].to_s).to eq(v)
+end
+
+Then(/^the output should be XML$/) do
+  @xml = Hash.from_xml(all_stdout)
 end

--- a/lib/csvlint/cli.rb
+++ b/lib/csvlint/cli.rb
@@ -144,13 +144,13 @@ module Csvlint
 
     def validate_csv(source, schema, dump, format, werror, verbose)
       @error_count = 0
-      @start = Time.now
+      start = Time.now
       validator = if !format.nil? or (verbose === false)
                     Csvlint::Validator.new(source, {}, schema)
                   else
                     Csvlint::Validator.new(source, {}, schema, lambda: report_lines)
                   end
-      @duration = Time.now - @start
+      duration = Time.now - start
 
       csv = if source.class == String
               source
@@ -162,7 +162,7 @@ module Csvlint
 
       if format === 'junit'
         x = Builder::XmlMarkup.new
-        xml = x.testsuite(:name => csv, :failures => validator.errors.length, :time => @duration) {
+        xml = x.testsuite(:name => csv, :failures => validator.errors.length, :time => duration) {
           validator.errors.map {
             |v| as_xml(x, v, "failure", csv)
           }


### PR DESCRIPTION
The output format for validation report can be set to JSON using the `--json` commandline argument, although this didn't work when also supplying a schema with `--schema`.

In order to test whether we can do Continuous Data Integration GSS-Cogs/sprint-planning#32, we need some machine-readable reports from our CSV validation tools and those reports need to fit with the continuous integration tool.

This PR changes the `--json` flag to a `--format` option where the user can supply either `json` for the existing (now fixed when used with `--schema`) JSON reports or `junit` for JUnit style XML reports.